### PR TITLE
Add: 특정 회원에 대한 측정 기록과 측정 데이터 생성

### DIFF
--- a/controllers/recordController.js
+++ b/controllers/recordController.js
@@ -6,6 +6,20 @@ const deleteRecord = async (req, res) => {
   res.status(200).json({ message: "측정 기록 삭제 성공" });
 };
 
+const createRecordData = async (req, res) => {
+  const { userId } = req.params;
+  const { weight, measuredAt, typeId, figure } = req.body;
+
+  try {
+    await recordService.createRecordData(userId, weight, measuredAt, typeId, figure);
+    res.status(201).json({ message: "RECORD_CREATED" });
+  } catch (err) {
+    console.log(err);
+    res.status(400).json({ message: "The entered figure is out of the allowed range." });
+  }
+};
+
 module.exports = {
   deleteRecord,
+  createRecordData,
 };

--- a/db/migrations/20221004123239_create_datas_table.sql
+++ b/db/migrations/20221004123239_create_datas_table.sql
@@ -5,8 +5,8 @@ CREATE TABLE datas(
     type_id INT NOT NULL,
     figure INT NOT NULL,
     FOREIGN KEY (record_id) REFERENCES records(id),
-    FOREIGN KEY (type_id) REFERENCES types(id)
-    ON DELETE CASCADE
+    FOREIGN KEY (type_id) REFERENCES types(id) ON DELETE CASCADE,
+    CONSTRAINT PK_datas_record_id_type_id UNIQUE KEY (record_id, type_id)
 );
 
 -- migrate:down

--- a/db/migrations/20221006092057_create_types_limits_table.sql
+++ b/db/migrations/20221006092057_create_types_limits_table.sql
@@ -1,0 +1,10 @@
+-- migrate:up
+CREATE TABLE types_limits (
+  type_id INT PRIMARY KEY,
+  figure_from INT,
+  figure_till INT
+);
+
+-- migrate:down
+DROP TABLE types_limits;
+

--- a/db/migrations/20221006092327_insert_types_limits_data.sql
+++ b/db/migrations/20221006092327_insert_types_limits_data.sql
@@ -1,0 +1,11 @@
+-- migrate:up
+INSERT INTO types_limits 
+VALUES 
+	(1, 0, 90),
+	(2, 30, 170),
+	(3, -60, -30),
+	(4, 0, 100),
+	(5, -100, 100);
+
+-- migrate:down
+

--- a/db/migrations/20221006092631_create_datas_trigger.sql
+++ b/db/migrations/20221006092631_create_datas_trigger.sql
@@ -1,0 +1,18 @@
+-- migrate:up
+CREATE TRIGGER tr_bi_check_limitations
+  BEFORE INSERT ON datas
+  FOR EACH ROW
+  BEGIN
+  IF NOT EXISTS ( 
+    SELECT NULL
+    FROM types_limits
+    WHERE type_id = NEW.type_id
+      AND NEW.figure BETWEEN figure_from AND figure_till
+    ) THEN
+    SIGNAL SQLSTATE '45015' 
+    SET message_text = 'The entered figure is out of the allowed range.' ;
+  END IF;
+  END
+
+-- migrate:down
+DROP TRIGGER tr_bi_check_limitations;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -21,12 +21,37 @@ CREATE TABLE `datas` (
   `type_id` int NOT NULL,
   `figure` int NOT NULL,
   PRIMARY KEY (`id`),
+  UNIQUE KEY `PK_datas_record_id_type_id` (`record_id`,`type_id`),
   KEY `type_id` (`type_id`),
-  KEY `datas_ibfk_1` (`record_id`),
   CONSTRAINT `datas_ibfk_1` FOREIGN KEY (`record_id`) REFERENCES `records` (`id`) ON DELETE CASCADE,
   CONSTRAINT `datas_ibfk_2` FOREIGN KEY (`type_id`) REFERENCES `types` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
+/*!50003 SET @saved_cs_client      = @@character_set_client */ ;
+/*!50003 SET @saved_cs_results     = @@character_set_results */ ;
+/*!50003 SET @saved_col_connection = @@collation_connection */ ;
+/*!50003 SET character_set_client  = utf8mb4 */ ;
+/*!50003 SET character_set_results = utf8mb4 */ ;
+/*!50003 SET collation_connection  = utf8mb4_general_ci */ ;
+/*!50003 SET @saved_sql_mode       = @@sql_mode */ ;
+/*!50003 SET sql_mode              = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION' */ ;
+DELIMITER ;;
+/*!50003 CREATE*/ /*!50017 DEFINER=`root`@`localhost`*/ /*!50003 TRIGGER `tr_bi_check_limitations` BEFORE INSERT ON `datas` FOR EACH ROW BEGIN
+  IF NOT EXISTS (
+    SELECT NULL
+    FROM types_limits
+    WHERE type_id = NEW.type_id
+      AND NEW.figure BETWEEN figure_from AND figure_till
+    ) THEN
+    SIGNAL SQLSTATE '45015'
+    SET message_text = 'The entered figure is out of the allowed range.' ;
+  END IF;
+  END */;;
+DELIMITER ;
+/*!50003 SET sql_mode              = @saved_sql_mode */ ;
+/*!50003 SET character_set_client  = @saved_cs_client */ ;
+/*!50003 SET character_set_results = @saved_cs_results */ ;
+/*!50003 SET collation_connection  = @saved_col_connection */ ;
 
 --
 -- Table structure for table `records`
@@ -43,7 +68,7 @@ CREATE TABLE `records` (
   PRIMARY KEY (`id`),
   KEY `user_id` (`user_id`),
   CONSTRAINT `records_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -59,25 +84,6 @@ CREATE TABLE `schema_migrations` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Table structure for table `tests4`
---
-
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `tests4` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `record_id` int NOT NULL,
-  `type_id` int NOT NULL,
-  `figure` int NOT NULL,
-  PRIMARY KEY (`id`),
-  KEY `type_id` (`type_id`),
-  KEY `record_id` (`record_id`),
-  CONSTRAINT `tests4_ibfk_2` FOREIGN KEY (`type_id`) REFERENCES `types` (`id`) ON DELETE CASCADE,
-  CONSTRAINT `tests4_ibfk_3` FOREIGN KEY (`record_id`) REFERENCES `records` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
 -- Table structure for table `types`
 --
 
@@ -85,9 +91,23 @@ CREATE TABLE `tests4` (
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `types` (
   `id` int NOT NULL AUTO_INCREMENT,
-  `name` varchar(200) COLLATE utf8mb4_general_ci NOT NULL,
+  `name` varchar(200) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `types_limits`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `types_limits` (
+  `type_id` int NOT NULL,
+  `figure_from` int DEFAULT NULL,
+  `figure_till` int DEFAULT NULL,
+  PRIMARY KEY (`type_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -98,16 +118,16 @@ CREATE TABLE `types` (
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `users` (
   `id` int NOT NULL AUTO_INCREMENT,
-  `name` varchar(200) COLLATE utf8mb4_general_ci NOT NULL,
+  `name` varchar(200) NOT NULL,
   `birth` date NOT NULL,
-  `phone_number` varchar(200) COLLATE utf8mb4_general_ci NOT NULL,
+  `phone_number` varchar(200) NOT NULL,
   `height` double NOT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `deleted_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `name` (`name`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -139,5 +159,8 @@ INSERT INTO `schema_migrations` (version) VALUES
   ('20221004123638'),
   ('20221004123645'),
   ('20221004123651'),
-  ('20221005090134');
+  ('20221005090134'),
+  ('20221006092057'),
+  ('20221006092327'),
+  ('20221006092631');
 UNLOCK TABLES;

--- a/models/recordDao.js
+++ b/models/recordDao.js
@@ -7,6 +7,25 @@ const deleteRecord = async (recordId) => {
   );
 };
 
+const createRecordData = async (userId, weight, measuredAt, typeId, figure) => {
+  await myDataSource.query(
+    `INSERT INTO records (user_id,weight,measured_at)
+  VALUES (?,?,?)`,
+    [userId, weight, measuredAt]
+  );
+
+  const typeAndFigure = typeId
+    .map((type, index) => `((SELECT LAST_INSERT_ID()),${type},${figure[index]})`)
+    .join(",");
+  const datas = await myDataSource.query(
+    `INSERT IGNORE INTO datas (record_id,type_id,figure)
+  VALUES ${typeAndFigure}`
+  );
+
+  return datas;
+};
+
 module.exports = {
   deleteRecord,
+  createRecordData,
 };

--- a/routes/recordRouter.js
+++ b/routes/recordRouter.js
@@ -3,4 +3,9 @@ const router = express.Router();
 const recordController = require("../controllers/recordController");
 
 router.delete("/:recordId", recordController.deleteRecord);
+
+router.post("/:userId", recordController.createRecordData);
+
+module.exports = router;
+
 module.exports = router;

--- a/services/recordService.js
+++ b/services/recordService.js
@@ -11,6 +11,30 @@ const deleteRecord = async (recordId) => {
   }
 };
 
+const createRecordData = async (userId, weight, measuredAt, typeId, figure) => {
+  const TYPE = {
+    SHOULDER_EXTENSION: 3,
+    SHOULDER_FLEXION: 2,
+  };
+
+  const hasShoulderType = typeId.some((type) =>
+    [TYPE.SHOULDER_EXTENSION, TYPE.SHOULDER_FLEXION].includes(type)
+  );
+
+  const isValidShoulderType =
+    typeId.filter((type) => type === TYPE.SHOULDER_EXTENSION || type === TYPE.SHOULDER_FLEXION)
+      .length === Object.keys(TYPE).length;
+
+  if (hasShoulderType && !isValidShoulderType) {
+    const error = new Error("SHOULDER_TYPE_ERROR");
+    error.code = 400;
+    throw error;
+  }
+
+  return await recordDao.createRecordData(userId, weight, measuredAt, typeId, figure);
+};
+
 module.exports = {
   deleteRecord,
+  createRecordData,
 };


### PR DESCRIPTION
## :: 최근 작업 주제
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 사항
- 측정 기록 - 측정데이터 타입 중복 불가 처리를 위한 (datas) record_id,type_id 복합 유니크키 생성
- 측정 기록 - 어깨 굴곡과 어깨 신전 중 하나만 들어올 경우에 대한 에러처리
- datas > figure 값 유효성 검사
  - types_limits 테이블 추가
  - BEFORE INSERT TRIGGER 생성
- 측정기록 - 측정데이터 여러개 생성> 배열로 받은 데이터 처리
- 측정기록, 측정데이터는 동시 생성